### PR TITLE
Partial changes to make Tildes run on other servers.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,7 +5,7 @@ VAGRANT_CONFIG_VERSION = "2"
 
 Vagrant.configure(VAGRANT_CONFIG_VERSION) do |config|
   # This should correspond to apt_distro in `salt/pillar`
-  config.vm.box = "ubuntu/xenial64"
+  config.vm.box = "ubuntu/bionic64"
 
   # Main application folder
   config.vm.synced_folder "tildes/", "/opt/tildes/"
@@ -26,7 +26,7 @@ Vagrant.configure(VAGRANT_CONFIG_VERSION) do |config|
       salt.log_level = "info"
 
       salt.install_type = "stable"
-      salt.version = "2019.2.3"
+      salt.version = "3000"
   end
 
   config.vm.provider "virtualbox" do |vb|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,6 +4,7 @@
 VAGRANT_CONFIG_VERSION = "2"
 
 Vagrant.configure(VAGRANT_CONFIG_VERSION) do |config|
+  # This should correspond to apt_distro in `salt/pillar`
   config.vm.box = "ubuntu/xenial64"
 
   # Main application folder

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -29,7 +29,7 @@ Vagrant.configure(VAGRANT_CONFIG_VERSION) do |config|
   end
 
   config.vm.provider "virtualbox" do |vb|
-      vb.memory = "4096"
-      vb.cpus = "4"
+      vb.memory = "2048"
+      vb.cpus = "1"
   end
 end

--- a/salt/pillar/dev.sls
+++ b/salt/pillar/dev.sls
@@ -1,3 +1,4 @@
+apt_distro: xenial
 gunicorn_args: --reload
 ini_file: development.ini
 ssl_cert_path: /etc/pki/tls/certs/localhost.crt

--- a/salt/pillar/dev.sls
+++ b/salt/pillar/dev.sls
@@ -1,4 +1,4 @@
-apt_distro: xenial
+apt_distro: bionic
 gunicorn_args: --reload
 ini_file: development.ini
 ssl_cert_path: /etc/pki/tls/certs/localhost.crt

--- a/salt/pillar/dev.sls
+++ b/salt/pillar/dev.sls
@@ -1,8 +1,6 @@
 apt_distro: bionic
 gunicorn_args: --reload
 ini_file: development.ini
-ssl_cert_path: /etc/pki/tls/certs/localhost.crt
-ssl_private_key_path: /etc/pki/tls/certs/localhost.key
 nginx_worker_processes: 1
 postgresql_version: 12
 prometheus_ips: ['127.0.0.1']

--- a/salt/pillar/monitoring.sls
+++ b/salt/pillar/monitoring.sls
@@ -1,5 +1,3 @@
-ssl_cert_path: /etc/letsencrypt/live/tildes.net/fullchain.pem
-ssl_private_key_path: /etc/letsencrypt/live/tildes.net/privkey.pem
 hsts_max_age: 60
 nginx_worker_processes: auto
 postgresql_version: 9.6

--- a/salt/pillar/prod.sls
+++ b/salt/pillar/prod.sls
@@ -1,3 +1,4 @@
+apt_distro: xenial
 gunicorn_args: --workers 8
 ini_file: production.ini
 ssl_cert_path: /etc/letsencrypt/live/tildes.net/fullchain.pem

--- a/salt/pillar/prod.sls
+++ b/salt/pillar/prod.sls
@@ -1,12 +1,11 @@
 apt_distro: bionic
 gunicorn_args: --workers 8
 ini_file: production.ini
-ssl_cert_path: /etc/letsencrypt/live/tildes.net/fullchain.pem
-ssl_private_key_path: /etc/letsencrypt/live/tildes.net/privkey.pem
 hsts_max_age: 63072000
 nginx_worker_processes: auto
 postgresql_version: 12
 prometheus_ips: ['2607:5300:201:3100::6e77']
+hostname: tildes.net
 site_hostname: tildes.net
 ipv6_address: '2607:5300:0203:2dd8::'
 ipv6_gateway: '2607:5300:0203:2dff:ff:ff:ff:ff'

--- a/salt/pillar/prod.sls
+++ b/salt/pillar/prod.sls
@@ -1,4 +1,4 @@
-apt_distro: xenial
+apt_distro: bionic
 gunicorn_args: --workers 8
 ini_file: production.ini
 ssl_cert_path: /etc/letsencrypt/live/tildes.net/fullchain.pem

--- a/salt/salt/common.jinja2
+++ b/salt/salt/common.jinja2
@@ -8,6 +8,10 @@
 
 {% if grains['id'] == 'dev' %}
   {% set app_username = 'vagrant' %}
+  {% set ssl_cert_path = '/etc/pki/tls/certs/localhost.crt' %}
+  {% set ssl_private_key_path = '/etc/pki/tls/certs/localhost.key' %}
 {% else %}
   {% set app_username = 'tildes' %}
+  {% set ssl_cert_path = '/etc/letsencrypt/live/' + pillar['hostname'] + '/fullchain.pem' %}
+  {% set ssl_cert_path = '/etc/letsencrypt/live/' + pillar['hostname'] + '/privkey.pem' %}
 {% endif %}

--- a/salt/salt/nginx/init.sls
+++ b/salt/salt/nginx/init.sls
@@ -1,7 +1,7 @@
 nginx:
   pkgrepo.managed:
-    - name: deb http://nginx.org/packages/ubuntu/ xenial nginx
-    - dist: xenial
+    - name: deb http://nginx.org/packages/ubuntu/ {{ pillar['apt_distro'] }} nginx
+    - dist: {{ pillar['apt_distro'] }}
     - file: /etc/apt/sources.list.d/nginx.list
     - key_url: https://nginx.org/keys/nginx_signing.key
     - require_in:

--- a/salt/salt/nginx/nginx.conf.jinja2
+++ b/salt/salt/nginx/nginx.conf.jinja2
@@ -1,3 +1,4 @@
+{% from 'common.jinja2' import ssl_cert_path, ssl_private_key_path %}
 user nginx;
 worker_processes {{ pillar['nginx_worker_processes'] }};
 
@@ -77,8 +78,8 @@ http {
       text/x-component
       text/x-cross-domain-policy;
 
-    ssl_certificate {{ pillar['ssl_cert_path'] }};
-    ssl_certificate_key {{ pillar['ssl_private_key_path'] }};
+    ssl_certificate {{ ssl_cert_path }};
+    ssl_certificate_key {{ ssl_private_key_path }};
     ssl_session_timeout 1d;
     ssl_session_cache shared:SSL:50m;
     ssl_session_tickets off;

--- a/salt/salt/nodejs.sls
+++ b/salt/salt/nodejs.sls
@@ -3,8 +3,8 @@
 # Add the NodeSource repository and install Node.js 10.x
 nodejs-pkgrepo:
   pkgrepo.managed:
-    - name: deb https://deb.nodesource.com/node_10.x xenial main
-    - dist: xenial
+    - name: deb https://deb.nodesource.com/node_10.x {{ pillar['apt_distro'] }} main
+    - dist: {{ pillar['apt_distro'] }}
     - file: /etc/apt/sources.list.d/nodesource.list
     - key_url: https://deb.nodesource.com/gpgkey/nodesource.gpg.key
     - require_in:

--- a/salt/salt/postgresql/init.sls
+++ b/salt/salt/postgresql/init.sls
@@ -2,8 +2,8 @@
 
 postgresql:
   pkgrepo.managed:
-    - name: deb http://apt.postgresql.org/pub/repos/apt/ xenial-pgdg main
-    - dist: xenial-pgdg
+    - name: deb http://apt.postgresql.org/pub/repos/apt/ {{ pillar['apt_distro'] }}-pgdg main
+    - dist: {{ pillar['apt_distro'] }}-pgdg
     - file: /etc/apt/sources.list.d/psql.list
     - key_url: https://www.postgresql.org/media/keys/ACCC4CF8.asc
     - require_in:


### PR DESCRIPTION
This PR is part of the effort to generalise the operational config of Tildes so that we can run it ourselves. The changes

* Abstract some (but not all) appereances of the hostname away into variables.
* Change the host OS from to ubuntu/bionic64 (and abstract away places where it is hard-coded).
* Pick a newer version of SaltStack.
* Use a smaller VM.

