### PR TITLE
Remove topic sort options

### DIFF
--- a/tildes/alembic/versions/d3ac50258ce3_remove_comment_sort_order_account_.py
+++ b/tildes/alembic/versions/d3ac50258ce3_remove_comment_sort_order_account_.py
@@ -1,0 +1,37 @@
+"""Remove comment sort order account setting
+
+Revision ID: d3ac50258ce3
+Revises: 4d86b372a8db
+Create Date: 2020-07-03 18:51:47.836251
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "d3ac50258ce3"
+down_revision = "4d86b372a8db"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_column("users", "comment_sort_order_default")
+    op.execute("drop type commenttreesortoption")
+
+
+def downgrade():
+    op.execute(
+        "create type commenttreesortoption as enum('VOTES', 'NEWEST', 'POSTED', 'RELEVANCE')"
+    )
+    op.add_column(
+        "users",
+        sa.Column(
+            "comment_sort_order_default",
+            postgresql.ENUM(
+                "VOTES", "NEWEST", "POSTED", "RELEVANCE", name="commenttreesortoption"
+            ),
+            nullable=True,
+        ),
+    )

--- a/tildes/tildes/models/user/user.py
+++ b/tildes/tildes/models/user/user.py
@@ -31,7 +31,6 @@ from sqlalchemy.sql.expression import text
 
 from tildes.enums import (
     CommentLabelOption,
-    CommentTreeSortOption,
     HTMLSanitizationContext,
     TopicSortOption,
 )
@@ -95,9 +94,6 @@ class User(DatabaseModel):
     inviter_id: int = Column(Integer, ForeignKey("users.user_id"))
     invite_codes_remaining: int = Column(Integer, nullable=False, server_default="0")
     collapse_old_comments: bool = Column(Boolean, nullable=False, server_default="true")
-    comment_sort_order_default: Optional[CommentTreeSortOption] = Column(
-        ENUM(CommentTreeSortOption)
-    )
     auto_mark_notifications_read: bool = Column(
         Boolean, nullable=False, server_default="false"
     )

--- a/tildes/tildes/templates/settings.jinja2
+++ b/tildes/tildes/templates/settings.jinja2
@@ -75,31 +75,6 @@
   <ul class="settings-list">
     <li>
       <form
-        name="account-default-comment-sort-order"
-        data-ic-patch-to="{{ request.route_url(
-          'ic_user',
-          username=request.user.username
-        ) }}"
-      >
-        <label class="form-label" for="comment-sort-order">Choose a default comment sort order:</label>
-        <select
-          class="form-select"
-          name="comment-sort-order"
-          id="comment-sort-order"
-          data-js-autosubmit-on-change
-        >
-          {% for sort_option in comment_sort_order_options %}
-            <option
-              value="{{ sort_option.name }}"
-              {{ 'selected' if current_comment_sort_order == sort_option else '' }}
-            >{{ sort_option.description|capitalize }}</option>
-          {% endfor %}
-        </select>
-      </form>
-    </li>
-
-    <li>
-      <form
         name="collapse-old-comments"
         autocomplete="off"
         data-ic-patch-to="{{ request.route_url('ic_user', username=request.user.username) }}"

--- a/tildes/tildes/templates/topic.jinja2
+++ b/tildes/tildes/templates/topic.jinja2
@@ -234,25 +234,6 @@
         <button class="btn btn-sm btn-light" data-js-comment-expand-all-button>Expand all</button>
       </div>
 
-      <form class="form-listing-options" method="get">
-        <div class="form-group">
-          <label for="comment_order">Comments sorted by</label>
-          <select id="comment_order" name="comment_order" class="form-select" data-js-autosubmit-on-change>
-            {% for option in comment_order_options %}
-              <option value="{{ option.name.lower() }}"
-
-              {% if option == comment_order %}
-                selected
-              {% endif %}
-              >{{ option.description }}</option>
-            {% endfor %}
-          </select>
-          {# add a submit button for people with js disabled so this is still usable #}
-          <noscript>
-            <button type="submit" class="btn btn-primary btn-sm">OK</button>
-          </noscript>
-        </div>
-      </form>
     </header>
   {% endif %}
 

--- a/tildes/tildes/views/api/web/user.py
+++ b/tildes/tildes/views/api/web/user.py
@@ -187,22 +187,6 @@ def patch_change_show_tags_in_listings(request: Request) -> Response:
 @ic_view_config(
     route_name="user",
     request_method="PATCH",
-    request_param="ic-trigger-name=account-default-comment-sort-order",
-    permission="change_settings",
-)
-def patch_change_comment_sort_order(request: Request) -> Response:
-    """Change the user's default comment sort order setting."""
-    user = request.context
-
-    comment_sort_order = request.params.get("comment-sort-order")
-    user.comment_sort_order_default = comment_sort_order
-
-    return IC_NOOP
-
-
-@ic_view_config(
-    route_name="user",
-    request_method="PATCH",
     request_param="ic-trigger-name=auto-mark-notifications-read",
     permission="change_settings",
 )

--- a/tildes/tildes/views/settings.py
+++ b/tildes/tildes/views/settings.py
@@ -60,14 +60,7 @@ def get_settings(request: Request) -> dict:
         theme_options[user_default_theme] += " (account default)"
         theme_options[site_default_theme] += " (site default)"
 
-    if request.user.comment_sort_order_default:
-        current_comment_sort_order = request.user.comment_sort_order_default
-    else:
-        current_comment_sort_order = CommentTreeSortOption.RELEVANCE
-
     return {
-        "current_comment_sort_order": current_comment_sort_order,
-        "comment_sort_order_options": CommentTreeSortOption,
         "theme_options": theme_options,
     }
 
@@ -236,9 +229,7 @@ def get_settings_theme_previews(request: Request) -> dict:
     for fake_comment in fake_comments:
         fake_comment.num_votes = 0
 
-    fake_tree = CommentTree(
-        fake_comments, CommentTreeSortOption.RELEVANCE, request.user
-    )
+    fake_tree = CommentTree(fake_comments, CommentTreeSortOption.NEWEST, request.user)
 
     # add a fake Exemplary label to the first child comment
     fake_comments[1].labels = [


### PR DESCRIPTION
This change forces all threads ("topics") to be viewed in newest-first
order. This is achieved by:

- Removing the sort order dropdown on the topic page
- Removing the `comment_order` parameter from the topic view and
  hardcoding the sort order to `NEWEST`
- Removing the default comment sort order option from the settings page,
  user model, and web API
- Creating an Alembic migration removing the setting from the DB schema

Closes #5