### PR TITLE
Fixed: Replaced "tildes.net" hard-coded string.

### DIFF
--- a/tildes/development.ini
+++ b/tildes/development.ini
@@ -38,6 +38,9 @@ sqlalchemy.url = postgresql+psycopg2://tildes:@:6432/tildes
 
 tildes.default_user_comment_label_weight = 1.0
 tildes.open_registration = true
+tildes.site_name = tildes.net
+tildes.donate_email = donate@tildes.net
+tildes.password_email = password@tildes.net
 
 webassets.auto_build = false
 webassets.base_dir = %(here)s/static

--- a/tildes/production.ini.example
+++ b/tildes/production.ini.example
@@ -28,6 +28,9 @@ stripe.recurring_donation_product_id = prod_ProductID
 tildes.default_user_comment_label_weight = 1.0
 tildes.welcome_message_sender = Deimos
 tildes.open_registration = true
+tildes.site_name = tildes.net
+tildes.donate_email = donate@tildes.net
+tildes.password_email = password@tildes.net
 
 webassets.auto_build = false
 webassets.base_dir = %(here)s/static

--- a/tildes/tildes/jinja.py
+++ b/tildes/tildes/jinja.py
@@ -46,9 +46,10 @@ def includeme(config: Configurator) -> None:
     config.add_jinja2_extension("jinja2.ext.do")
     config.add_jinja2_extension("webassets.ext.jinja2.AssetsExtension")
 
-    # attach webassets to jinja2 environment (via scheduled action)
-    def attach_webassets_to_jinja2() -> None:
+    # attach webassets to jinja2 and set SITE_NAME global (via scheduled action)
+    def setup_jinja_env() -> None:
         jinja2_env = config.get_jinja2_environment()
         jinja2_env.assets_environment = config.get_webassets_env()
+        jinja2_env.globals["SITE_NAME"] = settings["tildes.site_name"]
 
-    config.action(None, attach_webassets_to_jinja2, order=999)
+    config.action(None, setup_jinja_env, order=999)

--- a/tildes/tildes/lib/message.py
+++ b/tildes/tildes/lib/message.py
@@ -9,20 +9,20 @@ WELCOME_MESSAGE_SUBJECT = "Welcome to the Tildes alpha"
 WELCOME_MESSAGE_TEXT = """
 Hi, welcome to the Tildes alpha!
 
-If you haven't already, please read [the announcement post](https://blog.tildes.net/announcing-tildes) on the blog, since that explains a lot of the general goals and plans for the site.
+If you haven't already, please read [the announcement post](https://blog.{site_name}/announcing-tildes) on the blog, since that explains a lot of the general goals and plans for the site.
 
 Some quick information that should help with getting started:
 
 # Read about the basic mechanics
 
-There's a page on the Docs site that explains the basic mechanics on Tildes: https://docs.tildes.net/mechanics
+There's a page on the Docs site that explains the basic mechanics on Tildes: https://docs.{site_name}/mechanics
 
 # Check your user page sidebar
 
 There are multiple useful links in the sidebar on your user page&mdash;get there by clicking your username in the top right, or in the sidebar if you're on mobile. You can access the settings page from there, which includes multiple things you'll probably want to do:
 
 * Check the available options for display themes (including dark themes)
-* [Set up account recovery in case you lose access to your account](https://tildes.net/settings/account_recovery)
+* [Set up account recovery in case you lose access to your account](https://{site_name}/settings/account_recovery)
 
 # Please post topics and comments
 

--- a/tildes/tildes/templates/base.jinja2
+++ b/tildes/tildes/templates/base.jinja2
@@ -126,13 +126,13 @@
   </div>
 
   <ul class="site-footer-links">
-    <li class="site-footer-link"><a href="https://docs.tildes.net">Docs</a></li>
-    <li class="site-footer-link"><a href="https://blog.tildes.net">Blog</a></li>
-    <li class="site-footer-link"><a href="https://docs.tildes.net/contact">Contact</a></li>
+    <li class="site-footer-link"><a href="https://docs.{{ SITE_NAME }}">Docs</a></li>
+    <li class="site-footer-link"><a href="https://blog.{{ SITE_NAME }}">Blog</a></li>
+    <li class="site-footer-link"><a href="https://docs.{{ SITE_NAME }}/contact">Contact</a></li>
     <li class="site-footer-link"><a href="https://gitlab.com/tildes/tildes">Source code</a></li>
     <li class="site-footer-link"><a href="https://gitlab.com/tildes/tildes/issues?label_name[]=Feature+Request&label_name[]=Stage%3A%3AAccepted&scope=all&sort=priority&state=opened">Planned features</a> / <a href="https://gitlab.com/tildes/tildes/issues">All issues</a></li>
-    <li class="site-footer-link"><a href="https://docs.tildes.net/policies/privacy-policy">Privacy policy</a></li>
-    <li class="site-footer-link"><a href="https://docs.tildes.net/policies/terms-of-use">Terms of use</a></li>
+    <li class="site-footer-link"><a href="https://docs.{{ SITE_NAME }}/policies/privacy-policy">Privacy policy</a></li>
+    <li class="site-footer-link"><a href="https://docs.{{ SITE_NAME }}/policies/terms-of-use">Terms of use</a></li>
   </ul>
 </footer>
 

--- a/tildes/tildes/templates/donate_success.jinja2
+++ b/tildes/tildes/templates/donate_success.jinja2
@@ -2,13 +2,14 @@
 {# SPDX-License-Identifier: AGPL-3.0-or-later #}
 
 {% extends 'base_no_sidebar.jinja2' %}
+{% set donate_email = request.registry.settings['tildes.donate_email'] %}
 
 {% block title %}Thanks for donating!{% endblock %}
 
 {% block content %}
 <div class="empty">
   <h2 class="empty-title">Thanks for donating to Tildes!</h2>
-  <p class="empty-subtitle">You should receive an email receipt. If you have any questions, please feel free to contact <a href="mailto:donate@tildes.net">donate@tildes.net</a></p>
+  <p class="empty-subtitle">You should receive an email receipt. If you have any questions, please feel free to contact <a href="mailto:{{ donate_email }}">{{ donate_email }}</a></p>
 
   <div class="empty-action"><a href="/" class="btn btn-primary">Back to the home page</a></div>
 </div>

--- a/tildes/tildes/templates/financials.jinja2
+++ b/tildes/tildes/templates/financials.jinja2
@@ -30,7 +30,7 @@
 
 <p>The actual <em>costs</em> solely to keep Tildes running are much lower than this (see table below), but this represents the amount that I believe will make Tildes truly independently sustainable. It will cover all of the operating costs and also allow me (<a href="/user/Deimos">Deimos</a>) to pay myself a somewhat respectable (but low) salary of about $35,000/year. This goal may not be achievable in the near term, but it is the point where I will be comfortable focusing on Tildes without still needing to find additional outside income.</p>
 
-<p><a href="https://docs.tildes.net/donate">Please donate&mdash;any amount will help get us closer to the goal!</a></p>
+<p><a href="https://docs.{{ SITE_NAME }}/donate">Please donate&mdash;any amount will help get us closer to the goal!</a></p>
 
 <div class="divider"></div>
 

--- a/tildes/tildes/templates/login.jinja2
+++ b/tildes/tildes/templates/login.jinja2
@@ -2,6 +2,7 @@
 {# SPDX-License-Identifier: AGPL-3.0-or-later #}
 
 {% extends 'base_no_sidebar.jinja2' %}
+{% set pass_email = request.registry.settings['tildes.password_email'] %}
 
 {% block title %}Log In{% endblock %}
 
@@ -41,8 +42,8 @@
   <hr>
 
   {% if not request.registry.settings["tildes.open_registration"] %}
-    <p class="text-small">Tildes is currently in invite-only alpha, and you must be invited to be able to register. Most of the existing users have the ability to invite others, so if you know someone that has an account, you can ask them for an invite. Otherwise, please <a href="https://blog.tildes.net/announcing-tildes">read the announcement blog post</a> for more info about the site and instructions for requesting an invite from the site admin.</p>
+    <p class="text-small">Tildes is currently in invite-only alpha, and you must be invited to be able to register. Most of the existing users have the ability to invite others, so if you know someone that has an account, you can ask them for an invite. Otherwise, please <a href="https://blog.{{ SITE_NAME }}/announcing-tildes">read the announcement blog post</a> for more info about the site and instructions for requesting an invite from the site admin.</p>
   {% endif %}
 
-  <p class="text-small">If you already have a Tildes account but have forgotten your password, please send an email (you must include your username) to <a href="mailto:password@tildes.net">password@tildes.net</a>.</p>
+  <p class="text-small">If you already have a Tildes account but have forgotten your password, please send an email (you must include your username) to <a href="mailto:{{ pass_email }}">{{ pass_email }}</a>.</p>
 {% endblock %}

--- a/tildes/tildes/templates/macros/donation_goal.jinja2
+++ b/tildes/tildes/templates/macros/donation_goal.jinja2
@@ -29,6 +29,6 @@
 
     <p>Tildes is a non-profit site with no ads or investors, funded entirely by donations.</p>
 
-    <p><a href="https://docs.tildes.net/donate">Please donate</a> to support its continued development! (<a href="/financials">more details</a>)</p>
+    <p><a href="https://docs.{{ SITE_NAME }}/donate">Please donate</a> to support its continued development! (<a href="/financials">more details</a>)</p>
   </div>
 {% endmacro %}

--- a/tildes/tildes/templates/macros/forms.jinja2
+++ b/tildes/tildes/templates/macros/forms.jinja2
@@ -18,7 +18,7 @@
           >Preview</button>
         </li>
       </menu>
-      <a href="https://docs.tildes.net/instructions/text-formatting" target="_blank" tabindex="-1">Formatting help</a>
+      <a href="https://docs.{{ SITE_NAME }}/instructions/text-formatting" target="_blank" tabindex="-1">Formatting help</a>
     </header>
     <textarea
       class="form-input"
@@ -36,7 +36,7 @@
   <div class="form-autocomplete form-group" data-js-autocomplete-container data-js-ctrl-enter-submit-form>
     <label class="form-label" for="tags">
       <span>Tags (comma-separated)</span>
-      <a href="https://docs.tildes.net/instructions/posting-on-tildes#tagging-topics" target="_blank" tabindex="-1">Tagging help</a>
+      <a href="https://docs.{{ SITE_NAME }}/instructions/posting-on-tildes#tagging-topics" target="_blank" tabindex="-1">Tagging help</a>
     </label>
     <div class="form-autocomplete-input form-input">
       <div class="chips" data-js-autocomplete-chips></div>

--- a/tildes/tildes/templates/register.jinja2
+++ b/tildes/tildes/templates/register.jinja2
@@ -47,7 +47,7 @@
     <div class="form-group">
       <label class="form-checkbox">
         <input type="checkbox" id="accepted_terms" name="accepted_terms">
-        <i class="form-icon"></i> I accept the <a href="https://docs.tildes.net/policies/terms-of-use" target="_blank">Terms of Use</a> and <a href="https://docs.tildes.net/policies/privacy-policy" target="_blank">Privacy Policy</a>
+        <i class="form-icon"></i> I accept the <a href="https://docs.{{ SITE_NAME }}/policies/terms-of-use" target="_blank">Terms of Use</a> and <a href="https://docs.{{ SITE_NAME }}/policies/privacy-policy" target="_blank">Privacy Policy</a>
         <p class="text-small">They're short and written in plain language&mdash;please actually read them!</p>
       </label>
     </div>

--- a/tildes/tildes/templates/settings_account_recovery.jinja2
+++ b/tildes/tildes/templates/settings_account_recovery.jinja2
@@ -2,6 +2,7 @@
 {# SPDX-License-Identifier: AGPL-3.0-or-later #}
 
 {% extends 'base_settings.jinja2' %}
+{% set pass_email = request.registry.settings['tildes.password_email'] %}
 
 {% block title %}Set up account recovery{% endblock %}
 
@@ -15,7 +16,7 @@
 <p>Because of this, the account recovery process has to be initiated differently from most sites:</p>
 
 <ol>
-  <li>If you lose access to your account, send an email from the associated address to <a href="mailto:password@tildes.net">password@tildes.net</a>, requesting a password reset for that specific username.</li>
+  <li>If you lose access to your account, send an email from the associated address to <a href="mailto:{{ pass_email }}">{{ pass_email }}</a>, requesting a password reset for that specific username.</li>
   <li>The sending email address is hashed, and if the result matches the stored hash for that user, a message is sent back (to the same address) that includes a password reset link.</li>
   <li>You receive the email, reset your password, and are able to log into the account again.</li>
 </ol>

--- a/tildes/tildes/views/donate.py
+++ b/tildes/tildes/views/donate.py
@@ -50,6 +50,7 @@ def post_donate_stripe(
         stripe.api_key = request.registry.settings["api_keys.stripe.secret"]
         publishable_key = request.registry.settings["api_keys.stripe.publishable"]
         product_id = request.registry.settings["stripe.recurring_donation_product_id"]
+        site_name = request.registry.settings["tildes.site_name"]
     except KeyError:
         raise HTTPInternalServerError
 
@@ -60,15 +61,15 @@ def post_donate_stripe(
             payment_method_types=["card"],
             line_items=[
                 {
-                    "name": "One-time donation - tildes.net",
+                    "name": f"One-time donation - {site_name}",
                     "amount": int(amount * 100),
                     "currency": currency,
                     "quantity": 1,
                 }
             ],
             submit_type="donate",
-            success_url="https://tildes.net/donate_success",
-            cancel_url="https://docs.tildes.net/donate",
+            success_url=f"https://{site_name}/donate_success",
+            cancel_url=f"https://docs.{site_name}/donate",
         )
     else:
         product = stripe.Product.retrieve(product_id)
@@ -95,8 +96,8 @@ def post_donate_stripe(
         session = stripe.checkout.Session.create(
             payment_method_types=["card"],
             subscription_data={"items": [{"plan": plan.id}]},
-            success_url="https://tildes.net/donate_success",
-            cancel_url="https://docs.tildes.net/donate",
+            success_url=f"https://{site_name}/donate_success",
+            cancel_url=f"https://docs.{site_name}/donate",
         )
 
     return {"publishable_key": publishable_key, "session_id": session.id}

--- a/tildes/tildes/views/register.py
+++ b/tildes/tildes/views/register.py
@@ -124,8 +124,15 @@ def _send_welcome_message(recipient: User, request: Request) -> None:
     if not sender:
         return
 
+    site_name = request.registry.settings.get("tildes.site_name")
+    if not site_name:
+        return
+
     welcome_message = MessageConversation(
-        sender, recipient, WELCOME_MESSAGE_SUBJECT, WELCOME_MESSAGE_TEXT
+        sender,
+        recipient,
+        WELCOME_MESSAGE_SUBJECT,
+        WELCOME_MESSAGE_TEXT.format(site_name=site_name),
     )
     request.db_session.add(welcome_message)
 

--- a/tildes/tildes/views/settings.py
+++ b/tildes/tildes/views/settings.py
@@ -158,8 +158,10 @@ def get_settings_theme_previews(request: Request) -> dict:
     fake_user = request.query(User).filter(User.user_id == -1).one()
     group = request.query(Group).order_by(func.random()).limit(1).one()
 
+    site_name = request.registry.settings["tildes.site_name"]
+
     fake_link_topic = Topic.create_link_topic(
-        group, fake_user, "Example Link Topic", "https://tildes.net/"
+        group, fake_user, "Example Link Topic", f"https://{site_name}/"
     )
 
     fake_text_topic = Topic.create_text_topic(
@@ -182,7 +184,7 @@ def get_settings_theme_previews(request: Request) -> dict:
     # create a fake top-level comment that appears to be written by the user
     markdown = (
         "This is what a regular comment written by yourself would look like.\n\n"
-        "It has **formatting** and a [link](https://tildes.net)."
+        f"It has **formatting** and a [link](https://{site_name})."
     )
     fake_top_comment = Comment(fake_link_topic, request.user, markdown)
     fake_top_comment.comment_id = sys.maxsize

--- a/tildes/tildes/views/shortener.py
+++ b/tildes/tildes/views/shortener.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 """Views related to the link shortener."""
-
 from typing import NoReturn
 
 from pyramid.httpexceptions import HTTPMovedPermanently
@@ -14,12 +13,14 @@ from pyramid.view import view_config
 @view_config(route_name="shortener_group", permission=NO_PERMISSION_REQUIRED)
 def get_shortener_group(request: Request) -> NoReturn:
     """Redirect to the base path of a group."""
-    destination = f"https://tildes.net/~{request.context.path}"
+    site_name = request.registry.settings["tildes.site_name"]
+    destination = f"https://{site_name}/~{request.context.path}"
     raise HTTPMovedPermanently(location=destination)
 
 
 @view_config(route_name="shortener_topic", permission=NO_PERMISSION_REQUIRED)
 def get_shortener_topic(request: Request) -> NoReturn:
     """Redirect to the full permalink for a topic."""
-    destination = f"https://tildes.net{request.context.permalink}"
+    site_name = request.registry.settings["tildes.site_name"]
+    destination = f"https://{site_name}{request.context.permalink}"
     raise HTTPMovedPermanently(location=destination)


### PR DESCRIPTION
* In python, this is accomplished by reading from the .ini setting files when needed.

* In .jinja files, this is accomplished via a global that is set up in tildes/tildes/jinja.py. If not a global, the site-name would have to be passed as a parameter to every macro that needs it. I'm actually fine with this if everyone else is: just means some silly clutter in calling certain macros in jinja. If anything is general enough to be a global, I think "the name of the website" might be it.

* One string constant needs to be formatted down-stream (tildes/lib/message.py).

Also created constants for the donate and password reset emails, which are tied to the site name.