### PR TITLE
ui-improvements-11: adding left side border to post previews to bette…

### DIFF
--- a/tildes/scss/modules/_topic.scss
+++ b/tildes/scss/modules/_topic.scss
@@ -223,6 +223,8 @@
   margin: 0;
   overflow: hidden;
   font-style: italic;
+  border-left: 1px solid;
+  padding: 0.2rem 0.5rem;
 
   h1 {
     margin: 0 0 0.4rem;

--- a/tildes/scss/themes/_theme_base.scss
+++ b/tildes/scss/themes/_theme_base.scss
@@ -601,6 +601,7 @@
 
   .topic-text-excerpt {
     color: map-get($theme, "foreground-secondary");
+    border-left-color: map-get($theme, "border");
 
     summary::after {
       color: map-get($theme, "foreground-secondary");


### PR DESCRIPTION
…r visually distinguish them from surrounding elements, and clearly mark them as child content of the parent post content