### PR TITLE
Fixes a prettier extension problem with tabbing. In the package.json …

### DIFF
--- a/tildes/package.json
+++ b/tildes/package.json
@@ -40,7 +40,7 @@
     "bracketSpacing": false,
     "printWidth": 88,
     "proseWrap": "always",
-    "tabWidth": 4
+    "tabWidth": 2
   },
   "stylelint": {
     "ignoreFiles": [


### PR DESCRIPTION
…the prettier extension specifies 4 spaces to be used as tab width, but the linter rules require only 2 spaces to be used for tabs.