### PR TITLE
Salt: don't attempt to set mode on site-icons.css

### DIFF
--- a/salt/salt/webassets.sls
+++ b/salt/salt/webassets.sls
@@ -5,7 +5,6 @@
   file.managed:
     - user: {{ app_username }}
     - group: {{ app_username }}
-    - mode: 644
     - create: True
     - replace: False
 


### PR DESCRIPTION
Trying to change the mode of this file (which often already exists)
fails on Windows. It seems fine to just not set it and let it be set to
the default.